### PR TITLE
[FLIN-78] Fix conflicts from merging different views

### DIFF
--- a/flinkfood-demo/src/main/java/org/flinkfood/FlinkEnvironments/RestaurantTableEnvironment.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/FlinkEnvironments/RestaurantTableEnvironment.java
@@ -21,14 +21,12 @@ public class RestaurantTableEnvironment {
         " email STRING," +
         " cuisine_type STRING," +
         " price_range STRING," +
-        " vat_code INT," +
-        " source_timestamp TIMESTAMP(3) METADATA FROM 'value.source.timestamp'" +
+        " vat_code INT" +
         ") WITH (" +
         " 'connector' = 'kafka'," +
         " 'topic' = 'postgres.public.restaurant_info'," +
         " 'properties.bootstrap.servers' = 'localhost:9092'," +
-        " 'format' = 'debezium-json'," +
-        " 'debezium-json.schema-include' = 'true'," +
+        " 'format' = 'json'," +
         " 'scan.startup.mode' = 'earliest-offset'," +
         " 'properties.auto.offset.reset' = 'earliest'" +
         ")");
@@ -48,8 +46,7 @@ public class RestaurantTableEnvironment {
         " 'connector' = 'kafka'," +
         " 'topic' = 'postgres.public.restaurant_service'," +
         " 'properties.bootstrap.servers' = 'localhost:9092'," +
-        " 'format' = 'debezium-json'," +
-        " 'debezium-json.schema-include' = 'true'," +
+        " 'format' = 'json'," +
         " 'scan.startup.mode' = 'earliest-offset'," +
         " 'properties.auto.offset.reset' = 'earliest'" +
         ")");
@@ -68,8 +65,7 @@ public class RestaurantTableEnvironment {
         " 'connector' = 'kafka'," +
         " 'topic' = 'postgres.public.restaurant_address'," +
         " 'properties.bootstrap.servers' = 'localhost:9092'," +
-        " 'format' = 'debezium-json'," +
-        " 'debezium-json.schema-include' = 'true'," +
+        " 'format' = 'json'," +
         " 'scan.startup.mode' = 'earliest-offset'," +
         " 'properties.auto.offset.reset' = 'earliest'" +
         ")");
@@ -86,8 +82,7 @@ public class RestaurantTableEnvironment {
         " 'connector' = 'kafka'," +
         " 'topic' = 'postgres.public.restaurant_review'," +
         " 'properties.bootstrap.servers' = 'localhost:9092'," +
-        " 'format' = 'debezium-json'," +
-        " 'debezium-json.schema-include' = 'true'," +
+        " 'format' = 'json'," +
         " 'scan.startup.mode' = 'earliest-offset'," +
         " 'properties.auto.offset.reset' = 'earliest'" +
         ")");
@@ -106,8 +101,7 @@ public class RestaurantTableEnvironment {
         " 'connector' = 'kafka'," +
         " 'topic' = 'postgres.public.dish'," +
         " 'properties.bootstrap.servers' = 'localhost:9092'," +
-        " 'format' = 'debezium-json'," +
-        " 'debezium-json.schema-include' = 'true'," +
+        " 'format' = 'json'," +
         " 'scan.startup.mode' = 'earliest-offset'," +
         " 'properties.auto.offset.reset' = 'earliest'" +
         ")");
@@ -124,8 +118,7 @@ public class RestaurantTableEnvironment {
         " 'connector' = 'kafka'," +
         " 'topic' = 'postgres.public.review_dish'," +
         " 'properties.bootstrap.servers' = 'localhost:9092'," +
-        " 'format' = 'debezium-json'," +
-        " 'debezium-json.schema-include' = 'true'," +
+        " 'format' = 'json'," +
         " 'scan.startup.mode' = 'earliest-offset'," +
         " 'properties.auto.offset.reset' = 'earliest'" +
         ")");

--- a/flinkfood-demo/src/main/java/org/flinkfood/flinkjobs/CustomerViewJob.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/flinkjobs/CustomerViewJob.java
@@ -3,13 +3,7 @@ package org.flinkfood.flinkjobs;
 
 // Importing necessary Flink libraries and external dependencies
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.api.common.serialization.SimpleStringSchema;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.connector.mongodb.sink.MongoSink;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.kafka.source.KafkaSource;
@@ -20,10 +14,13 @@ import org.apache.flink.types.Row;
 import static org.apache.flink.table.api.Expressions.*;
 
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import com.mongodb.client.model.InsertOneModel;
-import org.bson.BsonDocument;
-import org.flinkfood.KafkaOrderSchema;
-import org.flinkfood.Order;
+import org.flinkfood.schemas.order.KafkaOrderSchema;
+import org.flinkfood.schemas.order.Order;
+import org.flinkfood.schemas.customer.Customer;
+import org.flinkfood.schemas.customer.Customer_address;
+import org.flinkfood.schemas.customer.KafkaAddressSchema;
+import org.flinkfood.schemas.customer.KafkaCustomerSchema;
+import org.flinkfood.serializers.GeneralRowToBsonDocument;
 
 // Class declaration for the Flink job
 public class CustomerViewJob {
@@ -75,7 +72,7 @@ public class CustomerViewJob {
                                 .setBatchIntervalMs(1000)
                                 .setMaxRetries(3)
                                 .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
-                                .setSerializationSchema(new RowToBsonDocument())
+                                .setSerializationSchema(new GeneralRowToBsonDocument())
                                 .build();
 
                 // Setting up Flink execution environment

--- a/flinkfood-demo/src/main/java/org/flinkfood/flinkjobs/DishViewJob.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/flinkjobs/DishViewJob.java
@@ -11,7 +11,10 @@ import org.apache.flink.table.api.*;
 import org.apache.flink.types.Row;
 import static org.apache.flink.table.api.Expressions.*;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.flinkfood.schemas.*;
+import org.flinkfood.schemas.dish.Dish;
+import org.flinkfood.schemas.dish.KafkaDishSchema;
+import org.flinkfood.schemas.restaurant.KafkaRestaurantInfoSchema;
+import org.flinkfood.schemas.restaurant.RestaurantInfo;
 
 // Class declaration for the Flink job
 public class DishViewJob {

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/Customer.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/Customer.java
@@ -1,4 +1,4 @@
-package org.flinkfood.flinkjobs;
+package org.flinkfood.schemas.customer;
 import java.util.Date;
 
 public class Customer {

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/Customer_address.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/Customer_address.java
@@ -1,4 +1,4 @@
-package org.flinkfood.flinkjobs;
+package org.flinkfood.schemas.customer;
 
 public class Customer_address {
 

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/KafkaAddressSchema.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/KafkaAddressSchema.java
@@ -1,12 +1,11 @@
-package org.flinkfood.flinkjobs;
+package org.flinkfood.schemas.customer;
+
+import java.io.IOException;
 
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.json.JsonMapper;
-import java.io.IOException;
-import java.time.Instant;
 
-public class KafkaCustomerSchema extends AbstractDeserializationSchema<Customer> {
+public class KafkaAddressSchema extends AbstractDeserializationSchema<Customer_address> {
 
     private static final long serialVersionUID = 1L;
     private transient ObjectMapper objectMapper;
@@ -17,8 +16,8 @@ public class KafkaCustomerSchema extends AbstractDeserializationSchema<Customer>
     }
 
     @Override
-    public Customer deserialize(byte[] message) throws IOException {
-        return objectMapper.readValue(message, Customer.class);
+    public Customer_address deserialize(byte[] message) throws IOException {
+        return objectMapper.readValue(message, Customer_address.class);
     }
 
 }

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/KafkaCustomerSchema.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/customer/KafkaCustomerSchema.java
@@ -1,11 +1,12 @@
-package org.flinkfood.flinkjobs;
-
-import java.io.IOException;
+package org.flinkfood.schemas.customer;
 
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.flinkfood.schemas.customer.Customer;
 
-public class KafkaAddressSchema extends AbstractDeserializationSchema<Customer_address> {
+import java.io.IOException;
+
+public class KafkaCustomerSchema extends AbstractDeserializationSchema<Customer> {
 
     private static final long serialVersionUID = 1L;
     private transient ObjectMapper objectMapper;
@@ -16,8 +17,8 @@ public class KafkaAddressSchema extends AbstractDeserializationSchema<Customer_a
     }
 
     @Override
-    public Customer_address deserialize(byte[] message) throws IOException {
-        return objectMapper.readValue(message, Customer_address.class);
+    public Customer deserialize(byte[] message) throws IOException {
+        return objectMapper.readValue(message, Customer.class);
     }
 
 }

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/dish/Dish.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/dish/Dish.java
@@ -1,4 +1,4 @@
-package org.flinkfood.schemas;
+package org.flinkfood.schemas.dish;
 
 public class Dish {
 

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/dish/KafkaDishSchema.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/dish/KafkaDishSchema.java
@@ -1,11 +1,11 @@
-package org.flinkfood.schemas;
+package org.flinkfood.schemas.dish;
 
 import java.io.IOException;
 
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
-public class KafkaRestaurantInfoSchema extends AbstractDeserializationSchema<RestaurantInfo> {
+public class KafkaDishSchema extends AbstractDeserializationSchema<Dish> {
 
     private static final long serialVersionUID = 1L;
     private transient ObjectMapper objectMapper;
@@ -16,8 +16,8 @@ public class KafkaRestaurantInfoSchema extends AbstractDeserializationSchema<Res
     }
 
     @Override
-    public RestaurantInfo deserialize(byte[] message) throws IOException {
-        return objectMapper.readValue(message, RestaurantInfo.class);
+    public Dish deserialize(byte[] message) throws IOException {
+        return objectMapper.readValue(message, Dish.class);
     }
 
 }

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/order/KafkaOrderSchema.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/order/KafkaOrderSchema.java
@@ -1,7 +1,7 @@
-package org.flinkfood;
+package org.flinkfood.schemas.order;
 
 import java.io.IOException;
-import org.flinkfood.Order;
+
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;;
 

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/order/Order.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/order/Order.java
@@ -1,4 +1,4 @@
-package org.flinkfood;
+package org.flinkfood.schemas.order;
 
 import java.sql.Date;
 

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/restaurant/KafkaRestaurantInfoSchema.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/restaurant/KafkaRestaurantInfoSchema.java
@@ -1,11 +1,12 @@
-package org.flinkfood.schemas;
+package org.flinkfood.schemas.restaurant;
 
 import java.io.IOException;
 
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.flinkfood.schemas.restaurant.RestaurantInfo;
 
-public class KafkaDishSchema extends AbstractDeserializationSchema<Dish> {
+public class KafkaRestaurantInfoSchema extends AbstractDeserializationSchema<RestaurantInfo> {
 
     private static final long serialVersionUID = 1L;
     private transient ObjectMapper objectMapper;
@@ -16,8 +17,8 @@ public class KafkaDishSchema extends AbstractDeserializationSchema<Dish> {
     }
 
     @Override
-    public Dish deserialize(byte[] message) throws IOException {
-        return objectMapper.readValue(message, Dish.class);
+    public RestaurantInfo deserialize(byte[] message) throws IOException {
+        return objectMapper.readValue(message, RestaurantInfo.class);
     }
 
 }

--- a/flinkfood-demo/src/main/java/org/flinkfood/schemas/restaurant/RestaurantInfo.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/schemas/restaurant/RestaurantInfo.java
@@ -1,4 +1,4 @@
-package org.flinkfood.schemas;
+package org.flinkfood.schemas.restaurant;
 
 public class RestaurantInfo {
 

--- a/flinkfood-demo/src/main/java/org/flinkfood/serializers/GeneralRowToBsonDocument.java
+++ b/flinkfood-demo/src/main/java/org/flinkfood/serializers/GeneralRowToBsonDocument.java
@@ -1,4 +1,4 @@
-package org.flinkfood.flinkjobs;
+package org.flinkfood.serializers;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.WriteModel;
 import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContext;
@@ -7,7 +7,7 @@ import org.apache.flink.types.Row;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 
-public class RowToBsonDocument implements MongoSerializationSchema<Row> {
+public class GeneralRowToBsonDocument implements MongoSerializationSchema<Row> {
 
     @Override
     public WriteModel<BsonDocument> serialize(Row row, MongoSinkContext mongoSinkContext) {


### PR DESCRIPTION

## Describe your changes
- Moved some files around into schemas/ and views/ to ensure better readability of the code
- Changed the deserialization in Flink SQL for RestaurantViews from debezium-json to json. This is because we are now using a different format on our kafka messages which looks like this:
```json
{
   "id": 1,
   "name": "Ristorante da Mario",
   "phone": "1234567890",
   "email": "mario.gmail.com",
   "cuisine_type": "italian",
   "price_range": "low",
   "vat_code": 2345678
}
```

While what our program expected was:
```json
{
 "schema": {
   "type": "struct",
   "fields": [
     {
       "type": "int64",
       "optional": false,
       "field": "id"
     },
     {
       "type": "string",
       "optional": false,
       "field": "name"
     }
   ],
   "optional": false,
   "name": "dbserver1.inventory.customers.Value",
   "field": "after"
 },
 "payload": {
   "after": {
     "id": 1005,
     "name": "Bob"
   }
 }
}
```

We do not need all these fields, so I would say the change is justified.

# Notes
In this PR all the views work by themselves. However, I will make a PR for running them all at the same time

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have updated/created the corresponding documentation
