### PR TITLE
[Hotfix] Change MONGO_URI and DB_TABLE in customer view

### DIFF
--- a/flinkfood-demo/CustomerViewJob/src/main/java/org/flinkfood/flinkjobs/CustomerViewJob.java
+++ b/flinkfood-demo/CustomerViewJob/src/main/java/org/flinkfood/flinkjobs/CustomerViewJob.java
@@ -13,9 +13,9 @@ import org.flinkfood.serializer.CustomerRowToBSON;;
 // Class declaration for the Flink job
 public class CustomerViewJob {
 
-    private static final String MONGODB_URI = "mongodb://localhost:27017";
+    private static final String MONGODB_URI = System.getenv("MONGODB_SERVER");
     private static final String SINK_DB = "flinkfood";
-    private static final String SINK_DB_TABLE = "testando";
+    private static final String SINK_DB_TABLE = "customer_view";
 
     // Main method where the Flink job is defined
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
## Describe your changes
When running the jobs using docker compose up -d --build customer view crashed after some minutes. The issue turned out to be that it tried to connect to a mongoDB server which it did not find. I changed the URI to the same we use in RestaurantView which fixed the issue inside docker. I have only tested this inside docker, so I do not know how it would work if you run it in a different way.

I also changed the table name to be a better fit for a demo
